### PR TITLE
Refactor: Navigation Type 에러 수정, eslint 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jest": "^29.6.3",
     "metro": "^0.80.9",
     "metro-core": "^0.80.9",
-    "prettier": "2.8.8",
+    "prettier": "^3.3.3",
     "react-test-renderer": "18.2.0",
     "typescript": "5.0.4"
   },

--- a/src/app/QueryProvider/index.tsx
+++ b/src/app/QueryProvider/index.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import {PropsWithChildren} from 'react';
+import React, {PropsWithChildren} from 'react';
 
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 

--- a/src/app/RootNavigator/index.tsx
+++ b/src/app/RootNavigator/index.tsx
@@ -4,6 +4,7 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 
 import TabNavigator from '@app/TabNavigator';
 import Detail from '@pages/Detail';
+import Loading from '@pages/Loading';
 import Main from '@pages/Main';
 import {RootStackParamList} from '@pages/types';
 
@@ -13,7 +14,7 @@ const RootNavigator = () => {
   return (
     <NavigationContainer>
       <Stack.Navigator
-        initialRouteName="Main"
+        initialRouteName="Loading"
         screenOptions={{
           headerStyle: {
             backgroundColor: '#f4511e',
@@ -23,6 +24,13 @@ const RootNavigator = () => {
             fontWeight: 'bold',
           },
         }}>
+        <Stack.Screen
+          name="Loading"
+          component={Loading}
+          options={{
+            headerShown: false,
+          }}
+        />
         <Stack.Screen
           name="Main"
           component={Main}

--- a/src/app/RootNavigator/index.tsx
+++ b/src/app/RootNavigator/index.tsx
@@ -5,8 +5,9 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import TabNavigator from '@app/TabNavigator';
 import Detail from '@pages/Detail';
 import Main from '@pages/Main';
+import {RootStackParamList} from '@pages/types';
 
-const Stack = createNativeStackNavigator();
+const Stack = createNativeStackNavigator<RootStackParamList>();
 
 const RootNavigator = () => {
   return (

--- a/src/app/TabNavigator/index.tsx
+++ b/src/app/TabNavigator/index.tsx
@@ -3,9 +3,9 @@ import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 
 import Home from '@pages/Home';
 import Settings from '@pages/Settings';
+import {TabParamList} from '@pages/types';
 
 import {AccountIcon, HomeIcon} from './tabBarIcon';
-import {TabParamList} from '@pages/types';
 
 const Tab = createBottomTabNavigator<TabParamList>();
 

--- a/src/app/TabNavigator/index.tsx
+++ b/src/app/TabNavigator/index.tsx
@@ -5,8 +5,9 @@ import Home from '@pages/Home';
 import Settings from '@pages/Settings';
 
 import {AccountIcon, HomeIcon} from './tabBarIcon';
+import {TabParamList} from '@pages/types';
 
-const Tab = createBottomTabNavigator();
+const Tab = createBottomTabNavigator<TabParamList>();
 
 const TabNavigator = () => {
   return (

--- a/src/pages/Detail/page.tsx
+++ b/src/pages/Detail/page.tsx
@@ -1,10 +1,3 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- */
-
 import React from 'react';
 import {SafeAreaView, Text, useColorScheme} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';

--- a/src/pages/Home/page.tsx
+++ b/src/pages/Home/page.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import {Button, SafeAreaView, Text, useColorScheme} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 
-import styles from './styles';
 import {TabScreenProps} from '@pages/types';
+
+import styles from './styles';
 
 const Page = (props: TabScreenProps<'Home'>) => {
   const {navigation} = props;

--- a/src/pages/Home/page.tsx
+++ b/src/pages/Home/page.tsx
@@ -1,10 +1,3 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- */
-
 import React from 'react';
 import {SafeAreaView, Text, useColorScheme} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';

--- a/src/pages/Home/page.tsx
+++ b/src/pages/Home/page.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import {SafeAreaView, Text, useColorScheme} from 'react-native';
+import {Button, SafeAreaView, Text, useColorScheme} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 
 import styles from './styles';
+import {TabScreenProps} from '@pages/types';
 
-const Page = () => {
+const Page = (props: TabScreenProps<'Home'>) => {
+  const {navigation} = props;
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {
@@ -16,6 +18,10 @@ const Page = () => {
       <Text>
         <Text style={styles.highlight}>Home</Text> Page!!
       </Text>
+      <Button
+        title="go to setting"
+        onPress={() => navigation.navigate('Settings', {text: 'test'})}
+      />
     </SafeAreaView>
   );
 };

--- a/src/pages/Loading/index.ts
+++ b/src/pages/Loading/index.ts
@@ -1,0 +1,3 @@
+import Loading from './page';
+
+export default Loading;

--- a/src/pages/Loading/page.tsx
+++ b/src/pages/Loading/page.tsx
@@ -6,7 +6,7 @@ import {RootStackScreenProps} from '@pages/types';
 
 import styles from './styles';
 
-const Page = (props: RootStackScreenProps<'Main'>) => {
+const Page = (props: RootStackScreenProps<'Loading'>) => {
   const {navigation} = props;
   const isDarkMode = useColorScheme() === 'dark';
 

--- a/src/pages/Loading/styles.ts
+++ b/src/pages/Loading/styles.ts
@@ -1,0 +1,17 @@
+import {StyleSheet} from 'react-native';
+
+const styles = StyleSheet.create({
+  highlight: {
+    fontWeight: '700',
+  },
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 40,
+  },
+});
+
+export default styles;

--- a/src/pages/Main/page.tsx
+++ b/src/pages/Main/page.tsx
@@ -1,12 +1,12 @@
 import React, {useEffect} from 'react';
 import {SafeAreaView, Text, useColorScheme} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
-import {useNavigation} from '@react-navigation/native';
 
 import styles from './styles';
+import {RootStackScreenProps} from '@pages/types';
 
-const Page = () => {
-  const navigation = useNavigation();
+const Page = (props: RootStackScreenProps<'Main'>) => {
+  const {navigation} = props;
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {
@@ -15,7 +15,10 @@ const Page = () => {
 
   useEffect(() => {
     setTimeout(() => {
-      navigation.navigate('Tab');
+      navigation.navigate('Tab', {
+        screen: 'Settings',
+        params: {text: 'Home Changed!'},
+      });
     }, 2000);
   }, [navigation]);
 

--- a/src/pages/Settings/page.tsx
+++ b/src/pages/Settings/page.tsx
@@ -10,8 +10,10 @@ import {SafeAreaView, Text, useColorScheme} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 
 import styles from './styles';
+import {TabScreenProps} from '@pages/types';
 
-const Page = () => {
+const Page = (props: TabScreenProps<'Settings'>) => {
+  const {route} = props;
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {
@@ -21,7 +23,8 @@ const Page = () => {
   return (
     <SafeAreaView style={backgroundStyle}>
       <Text>
-        <Text style={styles.highlight}>Setting</Text> Page!!
+        <Text style={styles.highlight}>Setting</Text> Page!! Params:{' '}
+        {route.params.text}
       </Text>
     </SafeAreaView>
   );

--- a/src/pages/Settings/page.tsx
+++ b/src/pages/Settings/page.tsx
@@ -9,8 +9,9 @@ import React from 'react';
 import {SafeAreaView, Text, useColorScheme} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 
-import styles from './styles';
 import {TabScreenProps} from '@pages/types';
+
+import styles from './styles';
 
 const Page = (props: TabScreenProps<'Settings'>) => {
   const {route} = props;

--- a/src/pages/types.ts
+++ b/src/pages/types.ts
@@ -1,11 +1,25 @@
-export {};
+import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
+import {
+  CompositeScreenProps,
+  NavigatorScreenParams,
+} from '@react-navigation/native';
+import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 
-declare global {
-  namespace ReactNavigation {
-    interface RootParamList {
-      Main: undefined;
-      Detail: undefined;
-      Tab: undefined;
-    }
-  }
-}
+export type RootStackParamList = {
+  Main: undefined;
+  Detail: undefined;
+  Tab: NavigatorScreenParams<TabParamList>;
+};
+
+export type TabParamList = {
+  Home: undefined;
+  Settings: {text: string};
+};
+
+export type RootStackScreenProps<T extends keyof RootStackParamList> =
+  NativeStackScreenProps<RootStackParamList, T>;
+
+export type TabScreenProps<T extends keyof TabParamList> = CompositeScreenProps<
+  BottomTabScreenProps<TabParamList, T>,
+  RootStackScreenProps<keyof RootStackParamList>
+>;

--- a/src/pages/types.ts
+++ b/src/pages/types.ts
@@ -6,6 +6,7 @@ import {
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 
 export type RootStackParamList = {
+  Loading: undefined;
   Main: undefined;
   Detail: undefined;
   Tab: NavigatorScreenParams<TabParamList>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6931,7 +6931,7 @@ __metadata:
     jest: ^29.6.3
     metro: ^0.80.9
     metro-core: ^0.80.9
-    prettier: 2.8.8
+    prettier: ^3.3.3
     react: 18.2.0
     react-native: 0.74.3
     react-native-safe-area-context: ^4.10.8
@@ -8152,12 +8152,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.8.8":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
+"prettier@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "prettier@npm:3.3.3"
   bin:
-    prettier: bin-prettier.js
-  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
+    prettier: bin/prettier.cjs
+  checksum: bc8604354805acfdde6106852d14b045bb20827ad76a5ffc2455b71a8257f94de93f17f14e463fe844808d2ccc87248364a5691488a3304f1031326e62d9276e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Navigation Type 정리
  - @pages/types에 각 Navigator 별 타입 정리
  - @react-navigation/native-stack 라이브러리의 유틸리티 타입으로 각 Navigator 타입 수정
  - 각 네비게이터의 하위 페이지는 `RootStackParamList` 또는 `TabParamList`에 `"페이지 명": "페이지 파라미터"`로 작성
- eslint 에러 수정
  - prettier 버전 업그레이드